### PR TITLE
Table code only

### DIFF
--- a/Clean_a-only_apps_table.sql
+++ b/Clean_a-only_apps_table.sql
@@ -1,0 +1,43 @@
+CREATE TABLE a_only_apps ( --new table name
+	a_name text, --new column names, in order
+	a_proj_mo_ls numeric,
+	a_proj_ls_earn money,
+	a_purch_price money,
+	a_proj_ls_main_cost money,
+	a_genre text,
+	a_content_rating text);
+			
+INSERT INTO a_only_apps(
+	a_name, --new column names, in order
+	a_proj_mo_ls,
+	a_proj_ls_earn,
+	a_purch_price,
+	a_proj_ls_main_cost,
+	a_genre,
+	a_content_rating)
+SELECT
+	(SELECT DISTINCT a.name 
+		WHERE a.name NOT NULL 
+		AND p.name NOT NULL
+		AND a.name '%' NOT LIKE p.name '%' ), --corresponding columns to be put into new table in order
+	ROUND(12*((ROUND (a.rating/5,1)*5)/.5)+12,0) AS a_proj_mo_ls, --calculates app store lifespan 
+	.5* CAST(5000 AS money)* ROUND(12*(a.rating/.5)+12,0) AS a_proj_ls_earn, --calculates app store ls earnings
+	(SELECT 
+	 	CASE  
+	 		WHEN CAST (a.price AS money) <= CAST(1.00 AS money) THEN  CAST (10000 AS money)
+	 		ELSE 10000 * CAST (a.price AS money) 
+	   		END AS a_purch_price) AS a_purc_price, --calculates app store purchase price
+	CAST (1000 AS money)*(1+.5*a.rating)*12 AS a_proj_ls_main_cost, --calculates app store ld maitenance costs
+	a.primary_genre,
+	a.content_rating
+FROM app_store_apps AS a
+INNER JOIN play_store_apps AS p
+ON a.name = p.name
+ORDER BY a.name;
+
+SELECT *
+FROM a_only_apps;
+/*SELECT COUNT (*)
+FROM a_only_apps;*/
+
+

--- a/Clean_a_p_common_table.sql
+++ b/Clean_a_p_common_table.sql
@@ -1,0 +1,61 @@
+CREATE TABLE a_p_common_apps ( --new table name
+	app_name text, --new column names, in order
+	a_proj_mo_ls numeric,
+	a_proj_ls_earn money,
+	a_purch_price money,
+	a_proj_ls_main_cost money,
+	a_genre text,
+	a_content_rating text,
+	p_proj_mo_ls numeric,
+	p_proj_ls_earn money,
+	p_purch_price money,
+	p_proj_ls_maint_cost money,
+	p_genre text,
+	p_content_rating text);
+			
+INSERT INTO a_p_common_apps(
+	app_name, --new column names, in order
+	a_proj_mo_ls,
+	a_proj_ls_earn,
+	a_purch_price,
+	a_proj_ls_main_cost,
+	a_genre,
+	a_content_rating,
+	p_proj_mo_ls,
+	p_proj_ls_earn,
+	p_purch_price,
+	p_proj_ls_maint_cost,
+	p_genre,
+	p_content_rating)
+SELECT
+	DISTINCT a.name, --corresponding columns to be put into new table in order
+	ROUND(12*((ROUND (a.rating/5,1)*5)/.5)+12,0) AS a_proj_mo_ls, --calculates app store lifespan 
+	.5* CAST(5000 AS money)* ROUND(12*(a.rating/.5)+12,0) AS a_proj_ls_earn, --calculates app store ls earnings
+	(SELECT 
+	 	CASE  
+	 		WHEN CAST (a.price AS money) <= CAST(1.00 AS money) THEN  CAST (10000 AS money)
+	 		ELSE 10000 * CAST (a.price AS money) 
+	   		END AS a_purch_price) AS a_purc_price, --calculates app store purchase price
+	CAST (1000 AS money)*(1+.5*a.rating)*12 AS a_proj_ls_main_cost, --calculates app store ld maitenance costs
+	a.primary_genre,
+	a.content_rating,
+	ROUND(12*((ROUND (p.rating/5,1)*5)/.5)+12,0) AS p_proj_mo_ls,--calculates play store lifespan 
+	(.5* CAST (5000 AS money)) * ROUND(12*(ROUND(12*(ROUND (p.rating/5,1) *5)+12,0)/.5)+12,0) AS p_proj_ls_earn,--calculates app store ls earnings
+	(SELECT 		
+	    CASE  
+	 		WHEN CAST (p.price AS money) <= CAST (1.00 AS money) THEN  CAST (10000 AS money)
+	 		ELSE 10000 * CAST (p.price AS money)
+	   		END AS p_purch_price) AS p_purch_price,--calculates app store purchase price
+	CAST (1000 AS money)*(1+.5*p.rating)*12 AS p_proj_ls_maint_cost,--calculates app store ld maitenance costs
+	p.genres,
+	p.content_rating 
+FROM app_store_apps AS a
+INNER JOIN play_store_apps AS p
+ON a.name= p.name
+ORDER BY a.name;
+
+SELECT *
+FROM a_p_common_apps;
+
+
+

--- a/a_p_common_profit.sql
+++ b/a_p_common_profit.sql
@@ -1,0 +1,20 @@
+SELECT 	
+	app_name,
+	(SELECT
+	 	CASE --selects longest lifespan
+			WHEN a_proj_mo_ls = p_proj_mo_ls THEN a_proj_mo_ls
+			WHEN a_proj_mo_ls > p_proj_mo_ls THEN a_proj_mo_ls
+			WHEN a_proj_mo_ls < p_proj_mo_ls THEN p_proj_mo_ls
+			END ) AS proj_lifespan,
+	a_proj_ls_earn + p_proj_ls_earn AS total_earn, --adds app and play earnings
+	a_purch_price + p_purch_price AS total_purch_price, --adds app and play purchase
+	(SELECT 
+		(a_proj_ls_earn + p_proj_ls_earn) - (a_purch_price + p_purch_price) +
+			(CASE --selects longest lifespan, which equals # mos.paying advertising
+			WHEN a_proj_ls_main_cost = p_proj_ls_maint_cost THEN a_proj_ls_main_cost
+			WHEN a_proj_ls_main_cost > p_proj_ls_maint_cost THEN a_proj_ls_main_cost
+			WHEN a_proj_ls_main_cost < p_proj_ls_maint_cost THEN p_proj_ls_maint_cost
+			END )) AS profit
+FROM a_p_common_apps
+ORDER BY profit DESC
+LIMIT 15;


### PR DESCRIPTION
Ignore Clean_a_only_apps_table.sql - doesn't populate names

 Clean_a_p_common_table.sql has only pertinent code, no commented out code. Matby use this for presentation

 a_p_common_profit.sql runs profit for apps in combined table